### PR TITLE
Fix Studentmediene logo on mobile

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -33,7 +33,7 @@
     <div class="container">
         <div id="header">
             <div class="row">
-                <div class="three columns"><img src="images/sm.png" /></div>
+                <div class="four columns"><img class="u-max-full-width" src="images/sm.png" /></div>
                 <div class="eight columns"><br><br>
                     <h2>Studentmediene i Trondheim</h2>
                     <h4>Norges største studentmediehus</h4>


### PR DESCRIPTION
Set max width of logo by using a skeleton utility class, stopping it from overflowing its container. 

Resolves #4