### PR TITLE
Fix links

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -46,14 +46,14 @@
     <div class="container">
         <div class="row">
             <div class="four columns value">
-                <a href="http://dusken.no">
+                <a href="https://dusken.no">
                     <img class="value-logo" src="images/dusken.svg" />
                 </a>
                 <h5 class="value-heading">Under Dusken og Dusken.no</h5>
                 <p class="value-description">Vårt magasin og nettavis dekker alle studentaktiviteter i Trondheim, og mer til!.</p>
             </div>
             <div class="four columns  value">
-                <a href="http://beta.radiorevolt.no">
+                <a href="https://radiorevolt.no">
                     <img class="value-logo" src="images/rr.png" />
                 </a>
                 <h5 class="value-heading">Radio Revolt</h5>
@@ -61,7 +61,7 @@
             </div>
 
             <div class="four columns value">
-                <a href="http://ibok.no">
+                <a href="https://ibok.no">
                     <img class="value-logo" src="images/ibok.svg" />
                 </a>
                 <h5 class="value-heading">iBok.no</h5>


### PR DESCRIPTION
The link to RadioRevolt.no was wrong, and pointed to the beta site.
It is corrected so it goes to the actual website.

The links did not go to the HTTPS version, this is also corrected.